### PR TITLE
Update pull request brong/Text-VCardFast#4

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,35 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.14'
+          - 'latest'
+
+    container:
+      image: perl:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: cpanm --quiet --notest --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,29 @@
+name: windows
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: cpanm --quiet --notest --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make test

--- a/vparse.c
+++ b/vparse.c
@@ -46,9 +46,25 @@ static void _buf_ensure(struct buf *buf, size_t n)
     buf->alloc = newalloc;
 }
 
+static char *mystrndup(const char *s, size_t n)
+{
+    size_t len = strlen(s);
+    char *new;
+
+    if (n < len)
+        len = n;
+
+    new = (char *) malloc(len + 1);
+    if (new == NULL)
+        return NULL;
+
+    new[len] = '\0';
+    return (char *) memcpy (new, s, len); /* NOLINT */
+}
+
 static char *buf_dup_cstring(struct buf *buf)
 {
-    char *ret = strndup(buf->s, buf->len);
+    char *ret = mystrndup(buf->s, buf->len);
     /* more space efficient than returning overlength buffers, and
      * you would just wind up mallocing another buffer anyway */
     buf->len = 0;


### PR DESCRIPTION
This PR updates https://github.com/brong/Text-VCardFast/pull/4. The PR adds GitHub Actions and adds `mystrncpy()` to `vparse.c`. 

I think that using `mystrncpy()` instead of `strncpy()` has two benefits:

1. [C23](https://en.wikipedia.org/wiki/C23_(C_standard_revision)) will add `strndup()` to C. `mystrncpy()` will never conflict with `strndup()`.
2. A static function that is added to `vparse.c` can be inlined by the compiler. Modern C compilers often optimize `strlen()` and `memcpy()` away.

The commits 13a3e63f59a4585314d3b63806fb753caed00a9a and 49654c1515be873cd34f6ca901d0f81226506742 can be removed with `git rebase -i 651ef0f48c17876accd921cda3d62e2f57e43e16` and pushed with `git push --force-with-lease`.

```
drop 13a3e63 Load our own strndup() on Windows
pick 18164cd Sort MANIFEST
drop 49654c1 Add Travis CI integration
pick 1695e0e Add GitHub actions
pick 1b22acb Add mystrndup()
````

If you prefer, I can create a new PR with my changes directly in https://github.com/brong/Text-VCardFast. 